### PR TITLE
FIX Make task work

### DIFF
--- a/src/Tasks/SecurityAlertCheckTask.php
+++ b/src/Tasks/SecurityAlertCheckTask.php
@@ -79,22 +79,25 @@ class SecurityAlertCheckTask extends BuildTask
 
         // use the security checker of
         $checker = $this->getSecurityChecker();
-        $alerts = $checker->check(BASE_PATH . DIRECTORY_SEPARATOR . 'composer.lock');
+        $result = $checker->check(BASE_PATH . DIRECTORY_SEPARATOR . 'composer.lock');
+        $alerts = json_decode((string) $result, true);
 
         // go through all alerts for packages - each can contain multiple issues
         foreach ($alerts as $package => $packageDetails) {
             // go through each individual known security issue
             foreach ($packageDetails['advisories'] as $details) {
                 $identifier = $this->discernIdentifier($details['cve'], $details['title']);
+                $vulnerability = null;
+
                 // check if this vulnerability is already known
-                $vulnerability = SecurityAlert::get()->filter(array(
+                $existingVulns = SecurityAlert::get()->filter(array(
                     'PackageName' => $package,
                     'Version' => $packageDetails['version'],
                     'Identifier'   => $identifier,
                 ));
 
                 // Is this vulnerability known? No, lets add it.
-                if ((int) $vulnerability->count() === 0) {
+                if (!$existingVulns->Count()) {
                     $vulnerability = SecurityAlert::create();
                     $vulnerability->PackageName  = $package;
                     $vulnerability->Version      = $packageDetails['version'];
@@ -108,17 +111,18 @@ class SecurityAlertCheckTask extends BuildTask
                     $validEntries[] = $vulnerability->ID;
                 } else {
                     // add existing vulnerabilities (probably just 1) to the list of valid entries
-                    $validEntries = array_merge($validEntries, $vulnerability->column('ID'));
+                    $validEntries = array_merge($validEntries, $existingVulns->column('ID'));
                 }
 
                 // Relate this vulnerability to an existing Package, if the
                 // bringyourownideas/silverstripe-maintenance module is installed
-                if ($vulnerability->hasExtension(SecurityAlertExtension::class)
+                if ($vulnerability && $vulnerability->hasExtension(SecurityAlertExtension::class)
                     && class_exists(Package::class)
-                    && $vulnerability->PackageRecordID === 0
+                    && !$vulnerability->PackageRecordID
                     && $packageRecord = Package::get()->find('Name', $package)
                 ) {
                     $vulnerability->PackageRecordID = $packageRecord->ID;
+                    $vulnerability->write();
                 }
             }
         }

--- a/tests/SecurityAlertCheckTaskTest.php
+++ b/tests/SecurityAlertCheckTaskTest.php
@@ -4,6 +4,7 @@ namespace BringYourOwnIdeas\SecurityChecker\Tests;
 
 use BringYourOwnIdeas\SecurityChecker\Models\SecurityAlert;
 use BringYourOwnIdeas\SecurityChecker\Tasks\SecurityAlertCheckTask;
+use SensioLabs\Security\Result;
 use SensioLabs\Security\SecurityChecker;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\SapphireTest;
@@ -99,7 +100,7 @@ CVENOTICE;
 
         $securityCheckerMock = $this->getMockBuilder(SecurityChecker::class)->setMethods(['check'])->getMock();
         $securityCheckerMock->expects($this->any())->method('check')->will($this->returnValue(
-            $empty ? [] : json_decode($mockOutput, true)
+            $empty ? new Result(0, '{}', 'json') : new Result(6, $mockOutput, 'json')
         ));
 
         return $securityCheckerMock;


### PR DESCRIPTION
Not sure how it was supposed to work before this fix.
Looking at the earliest stable release in the constraint
for https://github.com/sensiolabs/security-checker/tree/v5.0.0,
it mentions the use of json_decode() there.

We've previously looped over a JSON string,
and never created any security entries.

The bugfix around strict "=== 0" checks
might be a regression from framework, maybe
we used to set those foreign keys to 0,
and now we're leaving them null?
Either way, it's unnecessarily strict for this case.

And the write at the end ... that definitely didn't work.
So I guess we've got partial unit tests where the mocks work differently than the real API?