### PR TITLE
FIX Remove bottom margin from security alerts container

### DIFF
--- a/client/dist/css/securityalerts.css
+++ b/client/dist/css/securityalerts.css
@@ -2,6 +2,10 @@
   margin: 0;
 }
 
+.package-summary__security-alerts ul {
+  margin-bottom: 0;
+}
+
 .security-alerts__list {
   margin-top: 8px;
   display: none;


### PR DESCRIPTION
A small margin tweak:

![image](https://user-images.githubusercontent.com/5170590/54646662-b202ef80-4b04-11e9-864f-83e7f6146ea4.png)


![image](https://user-images.githubusercontent.com/5170590/54646657-aadbe180-4b04-11e9-854d-89aab52a3b9f.png)
