### PR TITLE
FIX Instantiate SecurityAlertCheckTask correctly in Job

### DIFF
--- a/src/Jobs/SecurityAlertCheckJob.php
+++ b/src/Jobs/SecurityAlertCheckJob.php
@@ -15,7 +15,7 @@ use Symbiote\QueuedJobs\Services\AbstractQueuedJob;
 class SecurityAlertCheckJob extends AbstractQueuedJob implements QueuedJob
 {
     private static $dependencies = [
-        'SecurityAlertCheckTask' => '%$' . SecurityAlertCheckTask::class,
+        'checkTask' => '%$' . SecurityAlertCheckTask::class,
     ];
 
     /**


### PR DESCRIPTION
~~`AbstractQueuedJob` does not implement the extensibility traits, so dependencies aren't injected automatically. This limitation was missed in the CMS 4 upgrade of the module.~~

Turns out the dependency was just named incorrectly 🙃 