### PR TITLE
Add v6 to sensiolabs/security-checker constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.6.0",
         "silverstripe/framework": "^4",
-        "sensiolabs/security-checker": "^6",
+        "sensiolabs/security-checker": "^5 || ^6",
         "symbiote/silverstripe-queuedjobs": "^4"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": ">=5.6.0",
         "silverstripe/framework": "^4",
-        "sensiolabs/security-checker": "^5",
+        "sensiolabs/security-checker": "^6",
         "symbiote/silverstripe-queuedjobs": "^4"
     },
     "require-dev": {


### PR DESCRIPTION
The conflict issue occurred during the installation of one of the SilverStripe modules (silverstripe/versioned-snapshot-admin) where one of its dependencies requires symfony/event-dispatcher v5 which conflicts with symfony/console[v4.4.7]. 

For reference, sensiolabs/security-checker v5.0.3 requires symfony/console (~2.7|~3.0|~4.0).